### PR TITLE
Require HostKeyCallback parameter (breaking change in golang crypto)

### DIFF
--- a/client.go
+++ b/client.go
@@ -70,12 +70,12 @@ type Auth struct {
 }
 
 // NewNativeClient creates a new Client using the golang ssh library
-func NewNativeClient(user, host, clientVersion string, port int, auth *Auth) (Client, error) {
+func NewNativeClient(user, host, clientVersion string, port int, auth *Auth, hostKeyCallback ssh.HostKeyCallback) (Client, error) {
 	if clientVersion == "" {
 		clientVersion = "SSH-2.0-Go"
 	}
 
-	config, err := NewNativeConfig(user, clientVersion, auth)
+	config, err := NewNativeConfig(user, clientVersion, auth, hostKeyCallback)
 	if err != nil {
 		return nil, fmt.Errorf("Error getting config for native Go SSH: %s", err)
 	}
@@ -89,7 +89,7 @@ func NewNativeClient(user, host, clientVersion string, port int, auth *Auth) (Cl
 }
 
 // NewNativeConfig returns a golang ssh client config struct for use by the NativeClient
-func NewNativeConfig(user, clientVersion string, auth *Auth) (ssh.ClientConfig, error) {
+func NewNativeConfig(user, clientVersion string, auth *Auth, hostKeyCallback ssh.HostKeyCallback) (ssh.ClientConfig, error) {
 	var (
 		authMethods []ssh.AuthMethod
 	)
@@ -114,10 +114,15 @@ func NewNativeConfig(user, clientVersion string, auth *Auth) (ssh.ClientConfig, 
 		}
 	}
 
+	if hostKeyCallback == nil {
+		hostKeyCallback = ssh.InsecureIgnoreHostKey()
+	}
+
 	return ssh.ClientConfig{
-		User:          user,
-		Auth:          authMethods,
-		ClientVersion: clientVersion,
+		User:            user,
+		Auth:            authMethods,
+		ClientVersion:   clientVersion,
+		HostKeyCallback: hostKeyCallback,
 	}, nil
 }
 


### PR DESCRIPTION
Hello, thanks for this awesome library!  Haven't been at it very long, but did notice the need to pass in a HostKeyCallback, because a commit made it required recently.

Hope this helps in some way.

Cheers!
nathan

**This is a breaking change! Beware!**

Breaking change
(https://github.com/golang/crypto/commit/e4e2799dd7aab89f583e1d898300d96367750991)
Requires HostKeyCallback for verifying ssh host keys during handshake.

To fix current code, all calls to NewNativeClient and NewNativeConfig
will need (at a minimum) an additional nil parameter passed to work
the same way this was working before.